### PR TITLE
Add build result check before push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn build


### PR DESCRIPTION
It will check whether build is successful before push and if build failed, `git push` won't work.